### PR TITLE
Add 'User Processed' type to GridPager

### DIFF
--- a/src/Mvc.Grid.Core/Paging/GridPager.cs
+++ b/src/Mvc.Grid.Core/Paging/GridPager.cs
@@ -63,6 +63,7 @@ namespace NonFactors.Mvc.Grid
 
         public String CssClasses { get; set; }
         public String PartialViewName { get; set; }
+        public GridPagerType PagerType { get; set; }
         public GridProcessorType ProcessorType { get; set; }
 
         private Int32 CurrentPageValue { get; set; }
@@ -76,13 +77,18 @@ namespace NonFactors.Mvc.Grid
             PagesToDisplay = 5;
             PartialViewName = "MvcGrid/_Pager";
             ProcessorType = GridProcessorType.Post;
+            PagerType = GridPagerType.GridProcessed;
         }
-
+        
         public virtual IQueryable<T> Process(IQueryable<T> items)
         {
-            TotalRows = items.Count();
-
-            return items.Skip((CurrentPage - 1) * RowsPerPage).Take(RowsPerPage);
+            if (PagerType == GridPagerType.UserProcessed 
+                && TotalRows >= items.Count()) //Defaults to GridProcessed if TotalRows hasn't been set
+                return items;
+            else { //(PagerType == GridPagerType.GridProcessed)
+                TotalRows = items.Count();
+                return items.Skip((CurrentPage - 1) * RowsPerPage).Take(RowsPerPage);
+            }
         }
     }
 }

--- a/src/Mvc.Grid.Core/Paging/GridPagerType.cs
+++ b/src/Mvc.Grid.Core/Paging/GridPagerType.cs
@@ -1,0 +1,8 @@
+﻿namespace NonFactors.Mvc.Grid
+{
+    public enum GridPagerType
+    {
+        GridProcessed,
+        UserProcessed
+    }
+}

--- a/src/Mvc.Grid.Core/Paging/IGridPager.cs
+++ b/src/Mvc.Grid.Core/Paging/IGridPager.cs
@@ -4,7 +4,7 @@ namespace NonFactors.Mvc.Grid
 {
     public interface IGridPager
     {
-        Int32 TotalRows { get; }
+        Int32 TotalRows { get; set; }
         Int32 TotalPages { get; }
 
         Int32 CurrentPage { get; set; }
@@ -15,6 +15,8 @@ namespace NonFactors.Mvc.Grid
 
         String CssClasses { get; set; }
         String PartialViewName { get; set; }
+
+        GridPagerType PagerType { get; set; }
     }
 
     public interface IGridPager<T> : IGridProcessor<T>, IGridPager


### PR DESCRIPTION
As discussed in issue #58. Made a bit of a shortcut and edited GridPager rather than adding another, of course you are welcome to discard this if it isn't how you would do it. :)

Allows for the paging to be dealt with by the user by setting pager.PagerType = GridPagerType.UserProcessed and pager.TotalRows = {calculated count}. It means the list partial action doesn't need to return the entire collection of models on each reload.

Consumed and tested as follows:-

View
```
@Html.Grid(Model)
    ....
    .Pageable(pager =>
    {
        pager.TotalRows = (int)ViewBag.TotalRows;
        pager.PagerType = GridPagerType.UserProcessed;
    })
```

Action
```
        public async Task<ActionResult> ListGrid(string search = "")
        {
            var page = Request.Query["ClientsGrid-Page"].ToString().ToNullable<int>() ?? 1;
            var rows = Request.Query["ClientsGrid-Rows"].ToString().ToNullable<int>() ?? 20;
            
            var clientsTask = _clientService.SearchClients(search, page, rows);
            var countTask = _clientService.CountClients(search);
            await Task.WhenAll(clientsTask, countTask);
            var clients = clientsTask.Result;
            ViewBag.TotalRows = countTask.Result;
            return PartialView("_ListGrid", clients.OrderBy(x => x.DateCreated));
        }
```

Side note: It would be quite useful if the 'ClientsGrid-Page' and 'ClientsGrid-Rows' query string params didn't have dashes so they could be consumed by the MVC model binding.