### PR TITLE
page is a reserved word on AspNetCore 2.0, so we use a different name

### DIFF
--- a/src/Mvc.Grid/Views/Shared/MvcGrid/_Pager.cshtml
+++ b/src/Mvc.Grid/Views/Shared/MvcGrid/_Pager.cshtml
@@ -22,15 +22,15 @@
                 <li class="disabled"><span>&laquo;</span></li>
                 <li class="disabled"><span>&lsaquo;</span></li>
             }
-            @for (Int32 page = firstDisplayPage; page <= totalPages && page < firstDisplayPage + Model.PagesToDisplay; page++)
+            @for (Int32 aPage = firstDisplayPage; aPage <= totalPages && aPage < firstDisplayPage + Model.PagesToDisplay; aPage++)
             {
-                if (page == currentPage)
+                if (aPage == currentPage)
                 {
-                    <li class="active" data-page="@page"><span>@page</span></li>
+                    <li class="active" data-page="@aPage"><span>@aPage</span></li>
                 }
                 else
                 {
-                    <li data-page="@page"><span>@page</span></li>
+                    <li data-page="@aPage"><span>@aPage</span></li>
                 }
             }
             @if (currentPage < totalPages)


### PR DESCRIPTION
Hi

I finally got time to try AspNet Core 2.0 and, well, the grid was not working.

The reason was quite interesting: now with razor pages, `page` ended up being a reserved word.

So I renamed the `page` variable and things work again.